### PR TITLE
Docs (readme): Add DELETE to dav_methods of nginx conf to allow deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For uploads to work you need to enable WebDav on the location, let's extend our 
         xslt_stylesheet /srv/autoindex.xslt;
 
 	client_body_temp_path /srv/temp; # Set to path where WebDav will save temporary files
-	dav_methods PUT;
+	dav_methods PUT DELETE;
 	add_header X-Options "WebDav"; # Important!
         create_full_put_path on;
         dav_access group:rw all:r;
@@ -78,7 +78,7 @@ Of course allowing anybody to upload any file to your server isn't the best idea
         xslt_stylesheet /srv/autoindex.xslt;
 
 	client_body_temp_path /srv/temp; # Set to path where WebDav will save temporary files
-	dav_methods PUT;
+	dav_methods PUT DELETE;
 	add_header X-Options "WebDav"; # Important!
         create_full_put_path on;
         dav_access group:rw all:r;
@@ -109,7 +109,7 @@ server {
 	auth_basic_user_file $htaccess_user_file;
 
 	client_body_temp_path /srv/temp;
-	dav_methods PUT;
+	dav_methods PUT DELETE;
 	add_header X-Options "WebDav"; # Important!
 	create_full_put_path on;
 	dav_access group:rw all:r;


### PR DESCRIPTION
~~Closes #1~~

Adds missing `DELETE` method among `dav_methods` directive of `nginx` config. This allows WebDAV deletions, or else the server returns `405`.